### PR TITLE
Release 0.8.1

### DIFF
--- a/keptn-in-a-box.sh
+++ b/keptn-in-a-box.sh
@@ -19,7 +19,7 @@
 # An installationBundle contains a set of multiple ins-   #
 # tallation functions.                                    #
 # Recommend to run the script like this:                  #
-#      sudo bash -c './keptn-in-a-box.sh &'               #
+#      sudo bash -c './keptn-in-a-box.sh'                 #
 # =========================================================
 YLW='\033[1;33m'
 NC='\033[0m'

--- a/keptn-in-a-box.sh
+++ b/keptn-in-a-box.sh
@@ -21,7 +21,52 @@
 # Recommend to run the script like this:                  #
 #      sudo bash -c './keptn-in-a-box.sh &'               #
 # =========================================================
+YLW='\033[1;33m'
+NC='\033[0m'
 
+printenv DT_TENANTID
+printenv DT_APITOKEN
+printenv DT_PAASTOKEN
+printenv DT_CERTMANAGER_EMAIL
+
+echo -e "${YLW}Please enter the credentials as requested below: ${NC}"
+read -e -i "${DT_TENANTID}" -p "Dynatrace Tenant ID ["${DT_TENANTID}"]: " iDTENVC
+DTENVC="${iDTENVC:-${DT_TENANTID}}"
+read -e -i "${DT_APITOKEN}" -p "Dynatrace API Token: ["${DT_APITOKEN}"]: " iDTAPIC
+DTAPIC="${iDTAPIC:-${DT_APITOKEN}}"
+read -e -i "${DT_PAASTOKEN}" -p "Dynatrace PaaS Token: ["${DT_PAASTOKEN}"]: " iDTPAAST
+DTPAAST="${iDTPAAST:-${DT_PAASTOKEN}}"
+read -e -i "${DT_CERTMANAGER_EMAIL}" -p "User Email ["${DT_CERTMANAGER_EMAIL}"]: " iDTUID
+DTUID="${iDTUID:-${DT_CERTMANAGER_EMAIL}}"
+echo ""
+
+if [ -z "$DTENVC" ]
+then
+      exit 1
+else
+      DTENV=$DTENVC
+      DTAPI=$DTAPIC
+fi
+
+echo ""
+echo -e "${YLW}Please confirm all are correct: ${NC}"
+echo "Dynatrace Tenant: $DTENV"
+echo "Dynatrace API Token: $DTAPI"
+echo "Dynatrace PaaS Token: $DTPAAST"
+echo "User Name: $DTUID"
+read -p "Is this all correct? (y/n) : " -n 1 -r
+echo ""
+
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+   TENANTID=$DTENV
+   APITOKEN=$DTAPI
+   PAASTOKEN=$DTPAAST
+   CERTMANAGER_EMAIL=$DTUID
+else 
+	exit 1   
+fi
+(
 # ==================================================
 #      ----- Variables Definitions -----           #
 # ==================================================
@@ -40,20 +85,27 @@ NEWPWD="secr3t"
 
 # ---- Define Dynatrace Environment ----
 # Sample: https://{your-domain}/e/{your-environment-id} for managed or https://{your-environment-id}.live.dynatrace.com for SaaS
-TENANT=
-PAASTOKEN=
-APITOKEN=
+#TENANT="https://${TENANTID}.live.dynatrace.com"
+#TENANT="https://${TENANTID}.sprint.dynatracelabs.com"
+TENANT="https://${TENANTID}"
+#PAASTOKEN=
+#APITOKEN=
+echo "tenant: $TENANT";
 
 # Set your custom domain e.g for an internal machine like 192.168.0.1.nip.io
 # So Keptn and all other services are routed and exposed properly via the Ingress Gateway
 # if no DOMAIN is setted, the public IP of the machine will be converted to a magic nip.io domain
 # ---- Define your Domain ----
-DOMAIN=
+#DOMAIN=
+DOMAIN="`curl http://checkip.amazonaws.com`.nip.io"
+# Magic domain for home/local cluster
+#DOMAIN="192.168.3.91.nip.io"
+
 
 # ---- The Email Account for the Certmanager ClusterIssuer with Let's encrypt ----
 # ---- By not providing an Email and letting certificates get generated will end up in
 # face Email accounts Enabling certificates with lets encrypt and not changing for your email will end up in cert rate limits for: nip.io: see https://letsencrypt.org/docs/rate-limits/
-CERTMANAGER_EMAIL=
+#CERTMANAGER_EMAIL=
 
 # ==================================================
 #      ----- Functions Location -----              #
@@ -145,3 +197,4 @@ installationBundleDemo
 #  ----- Call the Installation Function -----      #
 # ==================================================
 doInstallation
+) &


### PR DESCRIPTION
Changes to make install script run dynamically with user inputs.
The script will also read in environment variables, if they are set on the sudo user.

For the sudo user, the environment variables would need to be set as persistent variables via sudo visudo.
1) Add environment variables as the sudo user.
   if you run `sudo env` the environment variables should be set.
2) Then
` sudo visudo`
3) Then add 
`Defaults        env_keep +="DT_TENANTID DT_APITOKEN DT_PAASTOKEN DT_CERTMANAGER_EMAIL"`
 
 The other option is just to enter the variables as inputs.
 
 Also, the aws ip is read in dynamically, therefore the user does not need to enter the ip.
 Please check that part of the script. This is really geared towards deployments on Ubuntu and in AWS.
 
These changes do not require any changes to the functions file.

Future:
 look at ways to set the DOMAIN dynamically by cloud provider.  
 You can still override the DOMAIN by editing the script and setting the DOMAIN.
 
 Finally, you run the script without the &.
` sudo bash -c './keptn-in-a-box.sh'`

 This goes with ISSUE:
 Adapt the install script so the default installation is with interactive shell (easier for the users) #13
