### PR TITLE
Use OpenDNS for public IP lookup

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -406,8 +406,8 @@ setupMagicDomainPublicIp() {
     export DOMAIN
   else
     printInfo "No DOMAIN is defined, converting the public IP in a magic nip.io domain"
-    PUBLIC_IP=$(curl -s ifconfig.me)
-    PUBLIC_IP_AS_DOM=$(echo $PUBLIC_IP | sed 's~\.~-~g')
+    # https://unix.stackexchange.com/a/81699/37512
+    PUBLIC_IP_AS_DOM=$(dig @resolver4.opendns.com myip.opendns.com +short -4 | sed 's~\.~-~g')
     export DOMAIN="${PUBLIC_IP_AS_DOM}.nip.io"
     printInfo "Magic Domain: $DOMAIN"
   fi


### PR DESCRIPTION
An outage of ifconfig.me caused the script to fail.

I recommend to switch to a service with presumably higher availability standards, like OpenDNS.
Additionally explicit pinning to IPv4 address (who knows when ifconfig.me will enable IPv6 support)