### PR TITLE
Install snap and git as prerequisites

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -372,15 +372,18 @@ dynatracePrintValidateCredentials() {
 }
 
 dependenciesInstall() {
+  printInfoSection "Installing dependencies"
+  printInfo "Install snap"
+  apt install snapd -y
+  printInfo "Install git"
+  apt install git -y
+  printInfo "Install jq"
+  apt install jq -y
+}
+
+dockerInstall() {
   if [ "$docker_install" = true ]; then
-    printInfoSection "Installing dependencies"
-    printInfo "Install snap"
-    apt install snapd -y
-    printInfo "Install git"
-    apt install git -y
-    printInfo "Install jq"
-    apt install jq -y
-    printInfo "Install Docker"
+    printInfoSection "Installing Docker"
     apt install docker.io -y
     service docker start
     usermod -a -G docker $USER
@@ -861,6 +864,7 @@ doInstallation() {
   setupProAliases
 
   dependenciesInstall
+  dockerInstall
   microk8sInstall
   microk8sStart
   microk8sEnableBasic

--- a/functions.sh
+++ b/functions.sh
@@ -371,10 +371,14 @@ dynatracePrintValidateCredentials() {
   fi
 }
 
-dockerInstall() {
+dependenciesInstall() {
   if [ "$docker_install" = true ]; then
-    printInfoSection "Installing Docker and J Query"
-    printInfo "Install J Query"
+    printInfoSection "Installing dependencies"
+    printInfo "Install snap"
+    apt install snapd -y
+    printInfo "Install git"
+    apt install git -y
+    printInfo "Install jq"
     apt install jq -y
     printInfo "Install Docker"
     apt install docker.io -y
@@ -856,7 +860,7 @@ doInstallation() {
   updateUbuntu
   setupProAliases
 
-  dockerInstall
+  dependenciesInstall
   microk8sInstall
   microk8sStart
   microk8sEnableBasic


### PR DESCRIPTION
During the installation I ran into an issue that not all required dependencies might be installed in all images of Ubuntu.

Both images on Hetzner (Ubuntu 18.04LTS and 20.04LTS) were missing `snap` (the package is actually called snapd) and `git` on launch. This change should not impact distributions already containing these packages.

And as a sidenote:
I was happy to notice that it's not jQuery what is being installed during installation ;)